### PR TITLE
Fix local date bug

### DIFF
--- a/js/stable.js
+++ b/js/stable.js
@@ -121,6 +121,7 @@ roamsr.getFuckingDate = (str) => {
   if (strSplit.length != 3) return null;
   try {
     let date = new Date(strSplit[2] + "-" + strSplit[0] + "-" + strSplit[1]);
+    date.setTime( date.getTime() + date.getTimezoneOffset()*60*1000 )
     return date;
   } catch (e) {
     console.log(e);


### PR DESCRIPTION
This is a fantastic plugin. Thanks for making it!

I noticed a problem with the date parser that resulted in cards that were scheduled for tomorrow getting pulled into the review deck today. Turns out it was a timezone issue.

Given my timezone, the parser was returning tomorrow's date as today.

```
roamsr.getFuckingDate("02-19-2021")
# Thu Feb 18 2021 19:00:00 GMT-0500 (Eastern Standard Time)
```

The pull request incorporates a quick fix that I found to correct this (see the second answer):

https://stackoverflow.com/questions/439630/create-a-date-with-a-set-timezone-without-using-a-string-representation/439871#439871