### PR TITLE
Cache information about review blocks

### DIFF
--- a/src/core/loadingCards.js
+++ b/src/core/loadingCards.js
@@ -82,24 +82,24 @@ const srPageTagsToClause = (tags) => "(or " + tags.map((tag) => `[?srPage :node/
 //cards with the flag-tag or the "query"-tag are not permissible
 const createQueryForAllPermissibleCards = (settings) => `[
 			:find (pull ?card [
-			  :block/string 
-			  :block/uid 
-			  {:block/refs [:node/title]} 
-			  {:block/_refs 
-				[:block/uid :block/string 
-				 {:block/_children 
-						[:block/uid {:block/refs [:node/title]}]} 
-				 {:block/refs [:node/title]} 
+			  :block/string
+			  :block/uid
+			  {:block/refs [:node/title]}
+			  {:block/_refs
+				[:block/uid :block/string
+				 {:block/_children
+						[:block/uid {:block/refs [:node/title]}]}
+				 {:block/refs [:node/title]}
 				 {:block/page [:block/uid]}]}
 			  {:block/_children ...}
 			])
-			:where 
+			:where
 			  ${srPageTagsToClause(settings.mainTags)}
-			  [?card :block/refs ?srPage] 
-			  (not-join [?card] 
+			  [?card :block/refs ?srPage]
+			  (not-join [?card]
 				[?flagPage :node/title "${settings.flagTag}"]
 				[?card :block/refs ?flagPage])
-			  (not-join [?card] 
+			  (not-join [?card]
 				[?queryPage :node/title "query"]
 				[?card :block/refs ?queryPage])
 			]`;
@@ -129,25 +129,25 @@ const queryDueCards = async (settings, dateBasis, asyncQueryFunction) => {
 };
 
 const getTodayQuery = (settings, todayUid) => `[
-    :find (pull ?card 
-      [:block/uid 
-      {:block/refs [:node/title]} 
-      {:block/_refs 
+    :find (pull ?card
+      [:block/uid
+      {:block/refs [:node/title]}
+      {:block/_refs
 		[
 			{:block/page [:block/uid]}
-			{:block/_children 
+			{:block/_children
 				[:block/uid {:block/refs [:node/title]}]}
-		]}]) 
+		]}])
       (pull ?review [:block/refs])
-    :where 
+    :where
 	  ${srPageTagsToClause(settings.mainTags)}
-      [?card :block/refs ?srPage] 
-      [?review :block/refs ?card] 
-      [?reviewPage :node/title "roam/sr/review"] 
-      [?reviewParent :block/refs ?reviewPage] 
-      [?reviewParent :block/children ?review] 
-      [?todayPage :block/uid "${todayUid}"] 
-      [?reviewParent :block/page ?todayPage] 
+      [?card :block/refs ?srPage]
+      [?review :block/refs ?card]
+      [?reviewPage :node/title "roam/sr/review"]
+      [?reviewParent :block/refs ?reviewPage]
+      [?reviewParent :block/children ?review]
+      [?todayPage :block/uid "${todayUid}"]
+      [?reviewParent :block/page ?todayPage]
     ]`;
 
 const queryTodayReviewedCards = async (settings, asyncQueryFunction) => {
@@ -289,3 +289,13 @@ export const loadCards = async (hasLimits, settings, asyncQueryFunction, dateBas
 
 	return { extraCards: extraCardsResult, cards };
 };
+
+export const getReviewBlocks = () => {
+  return window.roamAlphaAPI.q(`[:find ?puid ?u :where
+    [?r :block/uid ?u]
+    [?r :block/refs ?b]
+    [?b :node/title "roam/sr/review"]
+    [?parent :block/children ?r]
+    [?parent :block/uid ?puid]
+  ]`);
+}

--- a/src/core/sessions.js
+++ b/src/core/sessions.js
@@ -1,6 +1,6 @@
 import { removeSelector, goToUid, sleep } from "./helperFunctions";
 import { addKeyListener, removeKeyListener } from "./keybindings";
-import { loadCards } from "./loadingCards";
+import { getReviewBlocks, loadCards } from "./loadingCards";
 import { goToCurrentCard } from "./mainFunctions";
 import { setCards, setCurrentCardIndex, setLimitActivation, standbyState } from "./state";
 import { setCustomStyle, removeCustomStyle, removeRoamsrMainviewCSS } from "../ui/styles";
@@ -33,6 +33,7 @@ export const loadState = async (i) => {
 	setLimitActivation(true);
 	setCurrentCardIndex(i);
 	const { cards, extraCards } = await loadCards(roamsr.state.limits, roamsr.settings, window.roamAlphaAPI.q);
+  roamsr.state.reviewBlocks = getReviewBlocks();
 	setCards(cards, extraCards);
 	updateCounters(roamsr.state);
 	return;


### PR DESCRIPTION
With a big database a query takes 3 seconds or more. That is a lot since a query is made on every single card. This pull request makes it so that a query is run only when it is absolutely necessary.

Can use this to see the difference:
`s.src =  "https://gregarious-daifuku-fbfc4b.netlify.app/js/stable.js";`